### PR TITLE
Update rusqlite_migration and related crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,9 +750,9 @@ dependencies = [
 
 [[package]]
 name = "deadpool-sqlite"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4378b597d51ce5586885f99c9c9dfd15bf39638c032b74739355cf11fc6ed3"
+checksum = "b8010e36e12f3be22543a5e478b4af20aeead9a700dd69581a5e050a070fc22c"
 dependencies = [
  "deadpool 0.10.0",
  "deadpool-sync",
@@ -961,9 +961,9 @@ dependencies = [
 
 [[package]]
 name = "fallible-iterator"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fallible-streaming-iterator"
@@ -1555,9 +1555,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc22eff61b133b115c6e8c74e818c628d6d5e7a502afea6f64dee076dd94326"
+checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2605,9 +2605,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549b9d036d571d42e6e85d1c1425e2ac83491075078ca9a15be021c56b1641f2"
+checksum = "a78046161564f5e7cd9008aff3b2990b3850dc8e0349119b98e8f251e099f24d"
 dependencies = [
  "bitflags 2.4.0",
  "chrono",
@@ -2620,8 +2620,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite_migration"
-version = "1.1.0-alpha.2"
-source = "git+https://github.com/cljoly/rusqlite_migration.git#ce4ce1c0a2bb417c71175acf388268838ee081df"
+version = "1.1.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5767f8cb28e54d1ed745f072b72c6e68bfa6179fabb4cd15bdb8575858e301d"
 dependencies = [
  "include_dir",
  "log",
@@ -3239,9 +3240,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rusqlite"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aa66395f5ff117faee90c9458232c936405f9227ad902038000b74b3bc1feac"
+checksum = "dc785c98d0c872455381e59be1f33a8f3a6b4e852544212e37601cc2ccb21d39"
 dependencies = [
  "crossbeam-channel",
  "rusqlite",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,7 +12,7 @@ chrono = { version = "0.4.24", features = ["serde"] }
 config = "0.13.3"
 console-subscriber = "0.2.0"
 data-encoding = "2.4.0"
-deadpool-sqlite = "0.6.0"
+deadpool-sqlite = "0.7.0"
 derive_builder = "0.12.0"
 dotenv = "0.15.0"
 futures = "0.3.28"
@@ -34,10 +34,10 @@ reqwest = "0.11.18"
 reqwest-middleware = "0.2.2"
 reqwest-tracing = "0.4.5"
 rspotify = "0.12.0"
-rusqlite = { version = "0.29.0", features = ["array", "bundled", "chrono"] }
-rusqlite_migration = { git = "https://github.com/cljoly/rusqlite_migration.git", features = [
+rusqlite = { version = "0.30.0", features = ["array", "bundled", "chrono"] }
+rusqlite_migration = { version = "1.1.0-beta.1", features = [
   "from-directory",
-  "async-tokio-rusqlite",
+  "alpha-async-tokio-rusqlite",
 ] }
 rust-s3 = "0.33.0"
 rustis = { version = "0.12.0", features = [
@@ -57,7 +57,7 @@ tokio = { version = "1.28.1", features = [
   "tracing",
 ] }
 tokio-retry = "0.3.0"
-tokio-rusqlite = "0.4.0"
+tokio-rusqlite = "0.5.0"
 tonic = "0.10.0"
 tonic-reflection = "0.10.0"
 tonic-web = "0.10.0"


### PR DESCRIPTION
I’ve released a new beta version of rusqlite_migration today and I’ve
renamed the `async-tokio-rusqlite` feature that you use to
`alpha-async-tokio-rusqlite`. I suggest updating dependencies as done in
this PR. By the way, if you would like to share feedback on the async
APIs, feel free to use this conversation:
https://github.com/cljoly/rusqlite_migration/discussions/127

Caveat: I could not run `cargo test` locally even on master, but `cargo
check` and `cargo build` did pass.
